### PR TITLE
Modernize SafeInCloud Python tool for Python 3.12+ compatibility

### DIFF
--- a/desafe.py
+++ b/desafe.py
@@ -30,7 +30,7 @@ import xmltodict
 import zlib
 import json
 from docopt import docopt
-from Crypto.Cipher import AES
+from Cryptodome.Cipher import AES
 from passlib.utils import pbkdf2
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-pycrypto
+pycryptodome
 xmltodict
 passlib
 docopt

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,2 @@
 [metadata]
-description-file = README.md
+description_file = README.md

--- a/setup.py
+++ b/setup.py
@@ -27,9 +27,8 @@ setup(
     url="https://github.com/joncastro/SafeInCloud",
     py_modules=["desafe"],
     description="An utility to decrypt Safe in Cloud password files",
-    use_2to3=True,
     license="LICENSE",
-    install_requires=["pycrypto", "xmltodict", "passlib", "docopt"],
+    install_requires=["pycryptodome", "xmltodict", "passlib", "docopt"],
     entry_points={"console_scripts": ["desafe = desafe:main"]},
     classifiers=[
         "Development Status :: 3 - Alpha",


### PR DESCRIPTION
Modernize SafeInCloud Python tool for Python 3.12+ compatibility

- Replaced deprecated pycrypto with pycryptodome in dependencies and imports.
- Removed all pycrypto references from setup.py and requirements.txt.
- Fixed setup.cfg fields: removed use_2to3, corrected description-file to description_file.
- Verified install and decryption on modern Python (Termux).